### PR TITLE
support nested errors object

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,16 +40,16 @@
     "prettier": "^1.19.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-hook-form": "^4.0.1",
     "react-test-renderer": "^16.9.0",
     "rollup": "^1.20.3",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-typescript2": "^0.25.2",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.7.2",
-    "react-hook-form": "^3.28.0"
+    "typescript": "^3.7.2"
   },
   "peerDependencies": {
     "react": "^16.8.0",
-    "react-hook-form": "^3.28.0"
+    "react-hook-form": "^4.0.0"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
-import { useFormContext } from 'react-hook-form';
-import { FieldError } from 'react-hook-form/dist/types';
+import {
+  useFormContext,
+  FieldErrors,
+  FieldError,
+  FieldName,
+} from 'react-hook-form';
+import get from './utils/get';
+import { FormValuesFromErrors, ErrorMessages } from './types';
 
-type ErrorFields = Record<string, FieldError>;
-type ErrorMessages = Record<string, string>;
-
-const RHFError = <Errors extends ErrorFields, Name extends keyof Errors>({
+const RHFError = <
+  Errors extends FieldErrors<any>,
+  Name extends FieldName<FormValuesFromErrors<Errors>>
+>({
   as,
   errors: errorsFromProps,
   name,
@@ -18,11 +24,8 @@ const RHFError = <Errors extends ErrorFields, Name extends keyof Errors>({
 }) => {
   const methods = useFormContext();
   const errors = errorsFromProps || (methods.errors as Errors);
-  const message =
-    errors &&
-    errors[name] &&
-    (errors[name].message || messages[errors[name].type]);
-
+  const error = get(errors, name) as FieldError | undefined;
+  const message = error && (error.message || messages[error.type]);
   if (!message) {
     return null;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+import { FieldErrors } from 'react-hook-form';
+
+export type FormValuesFromErrors<Errors> = Errors extends FieldErrors<
+  infer FormValues
+>
+  ? FormValues
+  : never;
+
+export type ErrorMessages = Record<string, string>;

--- a/src/utils/get.test.ts
+++ b/src/utils/get.test.ts
@@ -1,0 +1,22 @@
+import get from './get';
+
+describe('get', () => {
+  it('should get the right data', () => {
+    const test = {
+      bill: [1, 2, 3],
+      luo: [1, 3, { betty: 'test' }],
+      betty: { test: { test1: [{ test2: 'bill' }] } },
+    };
+    expect(get(test, 'bill')).toEqual([1, 2, 3]);
+    expect(get(test, 'bill[0]')).toEqual(1);
+    expect(get(test, 'luo[2].betty')).toEqual('test');
+    expect(get(test, 'betty.test.test1[0].test2')).toEqual('bill');
+  });
+
+  it('should get from the flat data', () => {
+    const test = {
+      bill: 'test',
+    };
+    expect(get(test, 'bill')).toEqual('test');
+  });
+});

--- a/src/utils/get.ts
+++ b/src/utils/get.ts
@@ -1,0 +1,13 @@
+import isUndefined from './isUndefined';
+import isNullOrUndefined from './isNullOrUndefined';
+
+export default (obj: any, path: string, defaultValue?: any) => {
+  const result = path
+    .split(/[,[\].]+?/)
+    .filter(Boolean)
+    .reduce(
+      (result, key) => (isNullOrUndefined(result) ? result : result[key]),
+      obj,
+    );
+  return isUndefined(result) || result === obj ? defaultValue : result;
+};

--- a/src/utils/isNullOrUndefined.test.ts
+++ b/src/utils/isNullOrUndefined.test.ts
@@ -1,0 +1,17 @@
+import isNullOrUndefined from './isNullOrUndefined';
+
+describe('isNullOrUndefined', () => {
+  it('should return true when object is null or undefined', () => {
+    expect(isNullOrUndefined(null)).toBeTruthy();
+    expect(isNullOrUndefined(undefined)).toBeTruthy();
+  });
+
+  it('should return false when object is neither null nor undefined', () => {
+    expect(isNullOrUndefined(-1)).toBeFalsy();
+    expect(isNullOrUndefined(0)).toBeFalsy();
+    expect(isNullOrUndefined(1)).toBeFalsy();
+    expect(isNullOrUndefined('')).toBeFalsy();
+    expect(isNullOrUndefined({})).toBeFalsy();
+    expect(isNullOrUndefined([])).toBeFalsy();
+  });
+});

--- a/src/utils/isNullOrUndefined.ts
+++ b/src/utils/isNullOrUndefined.ts
@@ -1,0 +1,4 @@
+import isUndefined from './isUndefined';
+
+export default (value: unknown): value is null | undefined =>
+  value === null || isUndefined(value);

--- a/src/utils/isUndefined.test.ts
+++ b/src/utils/isUndefined.test.ts
@@ -1,0 +1,19 @@
+import isUndefined from './isUndefined';
+
+describe('isUndefined', () => {
+  it('should return true when value is a undefined', () => {
+    expect(isUndefined(undefined)).toBeTruthy();
+  });
+
+  it('should return false when value is not a undefined', () => {
+    expect(isUndefined(null)).toBeFalsy();
+    expect(isUndefined('')).toBeFalsy();
+    expect(isUndefined(-1)).toBeFalsy();
+    expect(isUndefined(0)).toBeFalsy();
+    expect(isUndefined(1)).toBeFalsy();
+    expect(isUndefined({})).toBeFalsy();
+    expect(isUndefined([])).toBeFalsy();
+    expect(isUndefined(new String('test'))).toBeFalsy();
+    expect(isUndefined(() => null)).toBeFalsy();
+  });
+});

--- a/src/utils/isUndefined.ts
+++ b/src/utils/isUndefined.ts
@@ -1,0 +1,1 @@
+export default (val: unknown): val is undefined => val === undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,10 +4199,10 @@ react-dom@^16.9.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-hook-form@^3.28.0:
-  version "3.28.3"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-3.28.3.tgz#4f1424e9935e072e77bc36d3b07efcb3dbab426e"
-  integrity sha512-U4Ba/kGpqTD/2hjcKN4kc194cIGqfHGSIdykppkPVsCzMwVRXZRHAo3ep/RQtNxGVJ+hMnGPIJ5xGyG1Jq+2oA==
+react-hook-form@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-4.0.1.tgz#f376d76bec51109ad802f2820333c4ad2c76db49"
+  integrity sha512-nH8tr6K+EExriEgxOdgonULFFzmZLeFWmcjZlvhaRa5RESqaQ/ll3/6GzfqmukSFA0ZIqN+F1E6SQ3Ff4p2blg==
 
 react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.12.0"


### PR DESCRIPTION
Nested errors object is provided in RHF since version [v4](https://github.com/react-hook-form/react-hook-form/pull/666)

This component must also support it!
codesandbox: https://codesandbox.io/s/rhferror-support-nested-errors-object-bsm0e